### PR TITLE
pv上限設定についてのページを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ We welcome your feedback!
 Please open an **Issue** or join the **Discussions** tab to share your thoughts or propose improvements.  
 We currently do not accept pull requests unless they are discussed beforehand.
 
+### Branch Naming Convention
+
+When working on branches, please use the following naming format:
+`<type>/<summary>/<YYYYMMDD>`
+
+- `type`: Purpose of the change (e.g., `add`, `fix`, `update`)
+- `summary`: Short description in kebab-case
+- `YYYYMMDD`: Date the branch was created
+
+#### Examples:
+- `add/config-pv-limit/20250609`
+- `fix/broken-links/20250610`
+- `update/sidebar-order/20250611`
+
+
 ## Local Development
 
 ```bash

--- a/docs/user-manual/1-getting-started/installation.md
+++ b/docs/user-manual/1-getting-started/installation.md
@@ -71,6 +71,13 @@ To enable it:
 2. Check the **Advanced Mode** option  
 3. Click **Save Changes**
 
+### (Optional) Customize Monthly Data Collection Limit
+
+By default, QA Advisor collects up to **3,000 pageviews per month**.  
+You can change this limit by adding a line to your `wp-config.php` file.  
+[Learn how to configure the limit →](/docs/user-manual/getting-started/set-data-limit-wpconfig)
+
+
 ## Troubleshooting
 
 ### Plugin Won’t Activate?

--- a/docs/user-manual/1-getting-started/set-data-limit-wpconfig.md
+++ b/docs/user-manual/1-getting-started/set-data-limit-wpconfig.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 10
+title: Configure Monthly Limit
+id: set-data-limit-wpconfig
+---
+
+
+
+# Configuring Monthly Data Collection Limit
+
+QA Advisor limits the amount of data collected each month to **3,000 pageviews** by default.  
+This helps reduce server load and ensures stable performance on most WordPress hosting environments.
+
+If needed, you can change this limit by defining a constant in your WordPress site's `wp-config.php` file.
+
+
+---
+
+## How to Set the Monthly Data Limit
+
+Add the following line to your `wp-config.php`, preferably above the line that says `/* That's all, stop editing! Happy publishing. */`.
+
+```php
+define( 'QAHM_LIMIT_PV_MONTH', 10000 ); // Replace 10000 with your desired monthly limit
+```
+- The value must be an **integer**.
+- Once the limit is reached, QA Advisor will **stop collecting data** until the start of the next month.
+
+
+## ⚠️ Important Notes
+
+- Editing `wp-config.php` requires some familiarity with WordPress configuration files.  
+  If you're not comfortable doing so, we recommend consulting your developer or hosting provider.
+- Please use this setting with caution. Incorrect values may affect data collection or overall site performance.
+- The appropriate limit depends on your **server’s performance** and **expected traffic volume**.
+- The default limit of 3,000 per month is a conservative value intended to help prevent server overload.  
+  However, this does not guarantee stable operation on all servers.
+
+---
+
+## Example Use Cases
+
+- On a high-spec server, you might increase the limit to 10,000 or more.
+- On a shared or low-resource environment, you may wish to keep the default or lower it to 1,000 for testing.
+These examples help you determine a reasonable limit based on your server environment and site traffic.

--- a/docs/user-manual/1-getting-started/when-defer-jquery.md
+++ b/docs/user-manual/1-getting-started/when-defer-jquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 11
 title: When jQuery is Deferred
 id: when-defer-jquery
 ---

--- a/docs/user-manual/index.md
+++ b/docs/user-manual/index.md
@@ -1,10 +1,10 @@
 ---
-sidebar_position: 1
+sidebar_position: 0
 ---
 
 # User Guide
 
-Welcome to the QA Advisor User Manual. This comprehensive guide will help you get the most out of QA Advisor WordPress Analytics, from installation to advanced features.
+Welcome to the QA Advisor User Guide. This comprehensive guide will help you get the most out of QA Advisor WordPress Analytics, from installation to advanced features.
 
 ## What is QA Advisor?
 
@@ -15,9 +15,9 @@ QA Advisor (formerly QA Analytics) is a powerful WordPress analytics plugin that
 - **Detailed Reports**: Comprehensive analytics and user journey mapping
 - **Privacy-Focused**: GDPR compliant with user privacy in mind
 
-## Manual Structure
+## Guide Structure
 
-This manual is organized into the following sections:
+This guide is organized into the following sections:
 
 ### 📚 [1. Getting Started](/docs/user-manual/getting-started)
 Everything you need to begin using QA Advisor:


### PR DESCRIPTION
「pv上限をwp-configで設定する方法」ページを追加
readmeにブランチ命名ルールを追記