### PR TITLE
「Blog」を更新情報フィードに再構築（navbar 改名、RSS設定、テンプレ追加、i18n整備）

### DIFF
--- a/blog/2025-05-25-welcome.md
+++ b/blog/2025-05-25-welcome.md
@@ -1,15 +1,12 @@
 ---
 slug: welcome
 title: Welcome to QA Advisor Documentation
-authors:
-  name: QA Assistant Team
-  title: Documentation Team
-  url: https://github.com/quarka-org
-  image_url: https://github.com/quarka-org.png
 tags: [hello, docusaurus]
 ---
 
 Welcome to the new documentation site for QA Advisor WordPress Analytics!
+
+<!-- truncate -->
 
 This blog will contain updates about new features, tutorials, and best practices for using QA Advisor.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,18 @@ const config = {
           sidebarPath: './sidebars.js',
         },
         blog: {
-          showReadingTime: true,
+          showReadingTime: false,
+          blogTitle: 'Updates',
+          blogDescription: 'Release announcements and development updates for QA Assistants',
+          blogSidebarTitle: 'All posts',
+          blogSidebarCount: 'ALL',
+          postsPerPage: 'ALL',
+          feedOptions: {
+            type: ['rss', 'atom'],
+            title: 'QA Assistants Updates',
+            description: 'Release announcements and development updates for QA Assistants',
+            copyright: `Copyright © ${new Date().getFullYear()} Quarka Organization`,
+          },
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -81,13 +92,7 @@ const config = {
             position: 'left',
             label: 'Developer Guide',
           },
-          {to: '/blog', label: 'Blog', position: 'left'},
-          {
-            type: 'docSidebar',
-            sidebarId: 'releaseNotesSidebar',
-            position: 'left',
-            label: 'Release Notes',
-          },
+          {to: '/blog', label: 'Updates', position: 'left'},
           {
             type: 'docSidebar',
             sidebarId: 'faqSidebar',
@@ -138,12 +143,8 @@ const config = {
             title: 'More',
             items: [
               {
-                label: 'Blog',
+                label: 'Updates',
                 to: '/blog',
-              },
-              {
-                label: 'Release Notes',
-                to: '/docs/release-notes',
               },
             ],
           },

--- a/i18n/ja/docusaurus-plugin-content-blog/2025-05-25-welcome.md
+++ b/i18n/ja/docusaurus-plugin-content-blog/2025-05-25-welcome.md
@@ -1,15 +1,12 @@
 ---
 slug: welcome
 title: QA Advisorドキュメントへようこそ
-authors:
-  name: QA Advisor Team
-  title: Documentation Team
-  url: https://github.com/quarka-org
-  image_url: https://github.com/quarka-org.png
 tags: [hello, docusaurus]
 ---
 
 QA Advisor WordPress Analyticsの新しいドキュメントサイトへようこそ！
+
+<!-- truncate -->
 
 このブログでは、新機能、チュートリアル、QA Advisorを使用するためのベストプラクティスに関する更新情報を提供します。
 

--- a/i18n/ja/docusaurus-plugin-content-blog/options.json
+++ b/i18n/ja/docusaurus-plugin-content-blog/options.json
@@ -1,14 +1,14 @@
 {
   "title": {
-    "message": "Blog",
+    "message": "更新情報",
     "description": "The title for the blog used in SEO"
   },
   "description": {
-    "message": "Blog",
+    "message": "QA Assistants のリリース情報と開発の様子をお届けします",
     "description": "The description for the blog used in SEO"
   },
   "sidebar.title": {
-    "message": "Recent posts",
+    "message": "すべての投稿",
     "description": "The label for the left sidebar"
   }
 }

--- a/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/i18n/ja/docusaurus-theme-classic/footer.json
@@ -27,13 +27,9 @@
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/quarka-org"
   },
-  "link.item.label.Blog": {
-    "message": "ブログ",
-    "description": "The label of footer link with label=Blog linking to /blog"
-  },
-  "link.item.label.Release Notes": {
-    "message": "リリースノート",
-    "description": "The label of footer link with label=Release Notes linking to /docs/release-notes"
+  "link.item.label.Updates": {
+    "message": "更新情報",
+    "description": "The label of footer link with label=Updates linking to /blog"
   },
   "copyright": {
     "message": "Copyright © 2025 Quarka Organization. Docusaurus で構築されています。",

--- a/i18n/ja/docusaurus-theme-classic/navbar.json
+++ b/i18n/ja/docusaurus-theme-classic/navbar.json
@@ -11,13 +11,9 @@
     "message": "開発者ガイド",
     "description": "Navbar item with label Developer Guide"
   },
-  "item.label.Blog": {
-    "message": "ブログ",
-    "description": "Navbar item with label Blog"
-  },
-  "item.label.Release Notes": {
-    "message": "リリースノート",
-    "description": "Navbar item with label Release Notes"
+  "item.label.Updates": {
+    "message": "更新情報",
+    "description": "Navbar item with label Updates"
   },
   "item.label.FAQ": {
     "message": "よくある質問",

--- a/templates/blog-diary-template.md
+++ b/templates/blog-diary-template.md
@@ -1,0 +1,86 @@
+# 開発後記 投稿テンプレート
+
+月 1 ペースの「QA Platform 全体の中の人」視点コンテンツ。リリース告知ではなく、開発の様子・考えていることを共有する読み物。
+
+## 使い方
+
+1. 配置先:
+   - 英語版: `blog/YYYY-MM-DD-YYYY-MM-diary.md`（スタブで OK）
+   - 日本語版: `i18n/ja/docusaurus-plugin-content-blog/YYYY-MM-DD-YYYY-MM-diary.md`（本文を記載）
+2. `tags: [diary]` を必ず付ける
+3. 英語版は最小スタブで OK
+4. `slug` は `YYYY-MM-diary` 形式
+
+## 含めると良い要素
+
+- 今月のテーマ（1〜2 段落）
+- 取り組んだこと（スクショ・GIF を交えて 2〜3 個）
+- 考えていたこと（なぜそうしたか、検討した選択肢）
+- 次にやろうとしていること（フィードバックのフック）
+- 今月のリリース（マイナー含めた箇条書き）
+
+## 含めないもの
+
+- 内部実装の細かい技術的詳細
+- 未確定の方針
+
+## 英語版テンプレート（スタブ）
+
+`blog/YYYY-MM-DD-YYYY-MM-diary.md`:
+
+```markdown
+---
+slug: YYYY-MM-diary
+title: YYYY-MM Development Notes
+tags: [diary]
+date: YYYY-MM-DD
+---
+
+A monthly update from the QA Assistants development team.
+
+> 📝 The full development notes are written in Japanese.
+> See [Japanese version](/ja/blog/YYYY-MM-diary) for the full content.
+
+<!-- truncate -->
+
+This month's highlights:
+- ...
+```
+
+## 日本語版テンプレート
+
+`i18n/ja/docusaurus-plugin-content-blog/YYYY-MM-DD-YYYY-MM-diary.md`:
+
+```markdown
+---
+slug: YYYY-MM-diary
+title: YYYY年MM月の開発後記
+tags: [diary]
+date: YYYY-MM-DD
+---
+
+MM 月の開発状況をお伝えします。
+
+<!-- truncate -->
+
+## 今月のテーマ
+
+(その月に取り組んだ大きなテーマを 1〜2 段落で)
+
+## 取り組んだこと
+
+(スクショや GIF を交えてハイライトを 2〜3 個)
+
+## 考えていたこと
+
+(なぜそれをしたのか、どんな選択肢を検討したか)
+
+## 次にやろうとしていること
+
+(直近の予定、フィードバックのフック)
+
+## 今月のリリース
+
+- vX.X.X.X (M/D) — XXX を修正
+- vX.X.X.X (M/D) — YYY を改善
+```

--- a/templates/blog-release-template.md
+++ b/templates/blog-release-template.md
@@ -1,0 +1,114 @@
+# リリース告知 投稿テンプレート
+
+リリース時のお知らせ用テンプレート。プラグイン側「What's New」枠の表示元になる。
+
+## 使い方
+
+1. ファイル配置先:
+   - 英語版: `blog/YYYY-MM-DD-vX-X-X-X.md`
+   - 日本語版: `i18n/ja/docusaurus-plugin-content-blog/YYYY-MM-DD-vX-X-X-X.md`
+2. ファイル名は両方同じ
+3. `tags: [release]` を必ず付ける（プラグインのフィルタ条件）
+4. `slug` はバージョン番号（例: `v5-4-0-0`）
+5. `<!-- truncate -->` より上が一覧の抜粋になるので、最初の段落で要点を伝える
+
+## 投稿の判断基準
+
+- 機能追加・大きな改善・重要な修正など、**ユーザーに知らせる価値がある更新**のみ投稿
+- 軽微な内部改善や細かな修正は個別投稿せず、月次まとめか開発後記に組み込む
+- 詳細な変更履歴は `readme.txt` の Changelog セクションで担保（このブログには書かない）
+
+## チェックポイント
+
+- [ ] 重要更新ならスクリーンショットを最低 1 枚入れる（Before/After の対比を意識）
+- [ ] 英語版・日本語版で `slug` `date` `tags` を一致させる
+- [ ] タイトルは「vX.X.X.X — ○○」形式
+
+## 英語版テンプレート（重要更新）
+
+`blog/YYYY-MM-DD-vX-X-X-X.md` に配置:
+
+```markdown
+---
+slug: vX-X-X-X
+title: vX.X.X.X — Added ○○ Feature
+tags: [release]
+date: YYYY-MM-DD
+---
+
+vX.X.X.X has been released, featuring **a new ○○ functionality** and improvements.
+
+<!-- truncate -->
+
+## ✨ New Feature
+
+### ○○
+
+(Screenshot)
+
+(Description, use cases)
+
+## 🔧 Improvements
+
+- ...
+
+## 🐛 Bug Fixes
+
+- ...
+```
+
+## 英語版テンプレート（軽微な更新／月次まとめ）
+
+軽微な修正の独立告知や月次まとめの場合、英語版はスタブ程度で OK:
+
+```markdown
+---
+slug: vX-X-X-X
+title: vX.X.X.X — Patch Release
+tags: [release]
+date: YYYY-MM-DD
+---
+
+vX.X.X.X has been released with bug fixes and minor improvements.
+
+> 📝 Detailed release notes are available in Japanese.
+> See [Japanese version](/ja/blog/vX-X-X-X) for the full content.
+
+<!-- truncate -->
+
+- Bug fix: ...
+- Improvement: ...
+```
+
+## 日本語版テンプレート
+
+`i18n/ja/docusaurus-plugin-content-blog/YYYY-MM-DD-vX-X-X-X.md`:
+
+```markdown
+---
+slug: vX-X-X-X
+title: vX.X.X.X — ○○機能を追加しました
+tags: [release]
+date: YYYY-MM-DD
+---
+
+vX.X.X.X をリリースしました。今回は **○○機能の追加** と **△△ の改善** が主な変更です。
+
+<!-- truncate -->
+
+## ✨ 新機能
+
+### ○○機能
+
+(スクリーンショット)
+
+(機能の説明、使い方、想定シーン)
+
+## 🔧 改善
+
+- △△ の表示を見やすく改善
+
+## 🐛 不具合修正
+
+- ...
+```


### PR DESCRIPTION
「Blog」を更新情報フィードとして再構築

- navbar: Blog → Updates(更新情報)、Release Notes は navbar から削除
- blog 設定に RSS feedOptions を追加
- i18n/ja の navbar/footer/blog options を更新
- 投稿テンプレ 2 種(release/diary) を templates/ に追加
- welcome 投稿の authors ブロック削除＆truncate マーカー追加